### PR TITLE
migration bug fix #20

### DIFF
--- a/db/migrate/001_create_tables.rb
+++ b/db/migrate/001_create_tables.rb
@@ -9,7 +9,7 @@ class CreateTables < ActiveRecord::Migration
       t.column :name, :string, :unique=>true, :null => false
     end
 
-    Project.find(:all).each do |prj|
+    Project.all.each do |prj|
       OverviewBlock.new do |ob|
         ob.project_id = prj.id
         ob.name = 'members'


### PR DESCRIPTION
Object.find(:all) deprecated, instead of use Object.all.
